### PR TITLE
Electron packager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ version
 !package.json
 
 node_modules
+
+# electron-packager package results
+build

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   },
   "devDependencies": {
     "electron": "^1.3.2",
+    "electron-packager": "^8.0.0"
   },
   "scripts": {
-    "start": "node_modules/.bin/electron index.js"
+    "start": "node_modules/.bin/electron index.js",
+    "build": "electron-packager . --all --out=build --ignore=\"(build|.gitignore|.gidmodules|.gitattributes)\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
   },
   "dependencies": {
     "dialogs": "^1.1.15",
-    "electron": "^1.3.2",
     "jsonfile": "^2.3.1",
     "oauth": "^0.9.14",
     "request": "^2.74.0",
     "twitter": "^1.3.0",
     "twitter-text": "^1.14.0"
+  },
+  "devDependencies": {
+    "electron": "^1.3.2",
   },
   "scripts": {
     "start": "node_modules/.bin/electron index.js"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "scripts": {
     "start": "node_modules/.bin/electron index.js",
-    "build": "electron-packager . --all --out=build --ignore=\"(build|.gitignore|.gidmodules|.gitattributes)\""
+    "build": "electron-packager . --all --out=build --ignore=\"(build|.gitignore|.gitmodules|.gitattributes)\""
   }
 }


### PR DESCRIPTION
- move dependency `electron` to `devDependencies`.
- `npm run build` for make directories which include runnable binaries for each platform below folder `build`.
